### PR TITLE
Fix koeln add more ckan cities

### DIFF
--- a/odm/catalogs/portals/ckanApiV3.py
+++ b/odm/catalogs/portals/ckanApiV3.py
@@ -135,7 +135,9 @@ def gatherCity(cityname, url, apikey):
             pdata = json.loads(urldata)
             if 'success' in pdata and pdata['success']:
                 if cityname in dkanCities:
-                    groups.append(pdata['result'][0])
+                    # koeln has an empty dataset
+                    if len(pdata['result']) > 0:
+                        groups.append(pdata['result'][0])
                 else:
                     groups.append(pdata['result'])
             else:

--- a/odm/catalogs/portals/ckanApiV3.py
+++ b/odm/catalogs/portals/ckanApiV3.py
@@ -48,6 +48,10 @@ cities = {
             "url": "https://opendata.duesseldorf.de",
             "portalname": "opendata.duesseldorf.de"
         },
+        "wuppertal": {
+            "url": "https://offenedaten-wuppertal.de",
+            "portalname": "offenedaten-wuppertal.de"
+        },
         "bonn": {
             "url": "https://opendata.bonn.de",
             "portalname": "opendata.bonn.de"
@@ -56,7 +60,7 @@ cities = {
 
 offenesdatenportal = ("moers", "krefeld", "stadt-bottrop", "stadt-geldern", "stadt-kleve", "stadt-wesel", "kreis-wesel", "kreis-viersen", "kreis-kleve", "gemeinde-wachtendonk")
 
-dkanCities = ("bonn", "koeln", "gelsenkirchen", "duesseldorf")
+dkanCities = ("bonn", "koeln", "gelsenkirchen", "duesseldorf", "wuppertal")
 
 datenportalWithOrganisations = offenesdatenportal
 

--- a/odm/catalogs/portals/ckanApiV3.py
+++ b/odm/catalogs/portals/ckanApiV3.py
@@ -52,6 +52,10 @@ cities = {
             "url": "https://offenedaten-wuppertal.de",
             "portalname": "offenedaten-wuppertal.de"
         },
+        "muelheim-ruhr": {
+            "url": "https://geo.muelheim-ruhr.de",
+            "portalname": "geo.muelheim-ruhr.de"
+        },
         "bonn": {
             "url": "https://opendata.bonn.de",
             "portalname": "opendata.bonn.de"
@@ -60,7 +64,7 @@ cities = {
 
 offenesdatenportal = ("moers", "krefeld", "stadt-bottrop", "stadt-geldern", "stadt-kleve", "stadt-wesel", "kreis-wesel", "kreis-viersen", "kreis-kleve", "gemeinde-wachtendonk")
 
-dkanCities = ("bonn", "koeln", "gelsenkirchen", "duesseldorf", "wuppertal")
+dkanCities = ("bonn", "koeln", "gelsenkirchen", "duesseldorf", "wuppertal", "muelheim-ruhr")
 
 datenportalWithOrganisations = offenesdatenportal
 

--- a/odm/catalogs/portals/ckanApiV3.py
+++ b/odm/catalogs/portals/ckanApiV3.py
@@ -44,6 +44,10 @@ cities = {
             "url": "https://opendata.gelsenkirchen.de",
             "portalname": "opendata.gelsenkirchen.de"
         },
+        "duesseldorf": {
+            "url": "https://opendata.duesseldorf.de",
+            "portalname": "opendata.duesseldorf.de"
+        },
         "bonn": {
             "url": "https://opendata.bonn.de",
             "portalname": "opendata.bonn.de"
@@ -52,7 +56,7 @@ cities = {
 
 offenesdatenportal = ("moers", "krefeld", "stadt-bottrop", "stadt-geldern", "stadt-kleve", "stadt-wesel", "kreis-wesel", "kreis-viersen", "kreis-kleve", "gemeinde-wachtendonk")
 
-dkanCities = ("bonn", "koeln", "gelsenkirchen")
+dkanCities = ("bonn", "koeln", "gelsenkirchen", "duesseldorf")
 
 datenportalWithOrganisations = offenesdatenportal
 


### PR DESCRIPTION
## What does this PR do?

It adds three more DKAN cities to the gatherer. 
And fixes Köln gatherer since they have one [dataset](https://offenedaten-koeln.de/api/3/action/package_show?id=bev%C3%B6lkerung) which does have an empty result set. 