### PR TITLE
Fix category assignment

### DIFF
--- a/odm/catalogs/portals/ckanApiV3.py
+++ b/odm/catalogs/portals/ckanApiV3.py
@@ -251,12 +251,13 @@ def importCity(cityname, url, package):
             for extra in package['extras']:
                 if extra['key'] == 'contacts':
                     print 'WARNING: No author, but amazingly there is possibly data in the contacts: ' + extra['value']
-    for group in metautils.setofvaluesasarray(package[catskey], catssubkey):
-        if cityname != 'berlin':
-            odm_cats = metautils.govDataLongToODM(group)
-        else:
+    cat_groups = metautils.setofvaluesasarray(package[catskey], catssubkey)
+    if cityname != 'berlin':
+        odm_cats = metautils.matchCategories(cat_groups)
+    else:
+        for group in cat_groups:
             odm_cats = berlin_to_odm(group)
-        row[u'categories'] = odm_cats
+    row[u'categories'] = odm_cats
 
     row[u'Format'] = formats
     row[u'files'] = files

--- a/odm/catalogs/portals/ckanApiV3.py
+++ b/odm/catalogs/portals/ckanApiV3.py
@@ -307,7 +307,7 @@ class CkanReader(CatalogReader):
             d['metadata_xml'] = None
             d['formats'] = list(d['formats'])
             d['open'] = metautils.isopen(d['licenseshort'].strip())
-            if 'categoies' not in d:
+            if 'categories' not in d:
                 d['categories'] = []
             d['filelist'] = d['files']
         return d

--- a/odm/catalogs/utils/metautils.py
+++ b/odm/catalogs/utils/metautils.py
@@ -12,6 +12,23 @@ allfiletypes = tuple(allfiletypes)
 
 OPEN_LICENCES = ("cc-by", "odc-by", "cc-by 3.0", "dl-de-by-2.0", "dl-de/by-2-0", "cc-by-sa 3.0", "other-open", "cc0-1.0", "cc-zero", "dl-de-zero-2.0", "andere offene lizenzen", "cc by 3.0 de", "dl-de-by-1.0", "dl-de-by 1.0", "gfdl", "odbl", "cc-by-sa", "https://creativecommons.org/licenses/by/3.0/de/", "https://www.govdata.de/dl-de/by-2-0", "cc-by-3.0", "odc-odbl", "cc-by-4.0", "https://www.govdata.de/dl-de/zero-2-0")
 
+CATEGORIES = {
+        'Bildung und Wissenschaft': ['Bildung und Wissenschaft', 'Bildung', 'Wissenschaft'],
+        'Politik und Wahlen': ['Wahlen'],
+        u'Bevölkerung': [u'Bevölkerung'],
+        'Gesundheit': ['Gesundheit'],
+        'Transport und Verkehr': ['Transport und Verkehr', 'Verkehr', 'Transport'],
+        'Gesetze und Justiz': ['Gesetze und Justiz', 'Recht'],
+        'Wirtschaft und Arbeit': ['Wirtschaft und Arbeit'],
+        u'Öffentliche Verwaltung, Haushalt und Steuern': ['Verwaltung', 'Haushalt','Steuern'],
+        'Infrastruktur, Bauen und Wohnen': ['Infrastruktur', 'Bauen', 'Wohnen'],
+        'Geographie, Geologie und Geobasisdaten': ['Geo'],
+        'Soziales':['Soziales'],
+        'Kultur, Freizeit, Sport, Tourismus': ['Kultur', 'Freizeit', 'Sport', 'Tourismus'],
+        'Umwelt und Klima': ['Umwelt', 'Klima'],
+        'Verbraucherschutz': ['Verbraucherschutz'],
+        }
+
 def isopen(licensetext):
     if licensetext.lower() in OPEN_LICENCES:
         return 'Offen'
@@ -113,7 +130,6 @@ def govDataLongToODM(group, checkAll=False):
     # This is designed to cope either with a single category or a string with all categories. Quotes are allowed.
     # It has been extended to include the wild moers categories
     # Eventually, we need one function that matches all words, short and long to the govdata categories
-    group = group.strip()
     returnvalue = []
     if u'Bevölkerung' in group:
         returnvalue.append(u'Bevölkerung')
@@ -209,9 +225,22 @@ def long_license_to_short(licensetext):
     print 'Could not shorten ' + findLcGermanCharsAndReplace(licensetext.lower()) + ' (lower cased, dspec. chars removed). This may be OK if there is no sensible short form.'
     return licensetext
 
+def keyForMatched(key, values, match):
+    if any(v in match for v in values):
+        return key
+
+def matchCategory(category):
+    categories = filter(None,[keyForMatched(k,v,category) for k,v in CATEGORIES.iteritems()])
+    if len(categories) > 0:
+        return categories[0]
+
+def matchCategories(categories):
+    matchedCategories = [matchCategory(c) for c in categories]
+    return matchedCategories
 
 def setofvaluesasarray(arrayvalue, keyvalue):
     simplearray = []
     for item in arrayvalue:
         simplearray.append(item[keyvalue])
     return simplearray
+

--- a/tests/catalog_test.py
+++ b/tests/catalog_test.py
@@ -170,12 +170,12 @@ class TestCKANAPIV3(object):
             body='{"result": ["bürgeranträge-gem-§-24-go-nrw"]}',
             content_type="application/json")
         httpretty.register_uri(httpretty.GET, "https://opendata.bonn.de/api/3/action/package_show?id="+datasetId,
-            body='{"result": []}',
+                body='{"success": true, "result": [{}]}',
             content_type="application/json")
         reader = CkanReader('bonn')
         result = reader.gather()
         assert (httpretty.has_request())
-        assert len(result) == 0
+        assert len(result) == 1
 
 
     def test_bonn_special(self):
@@ -190,4 +190,11 @@ class TestCKANAPIV3(object):
         d = reader.import_data(ckan_result)
         print(d)
         assert d['open'] == 'Offen'
+
+    def test_is_open_import(self):
+        ckan_result = { "name": "test", "license_id": "dl-de-zero-2.0", "private": "", "title": "Test", "groups": [{'title': 'Wahlen'}] }
+        reader = CkanReader('moers')
+        d = reader.import_data(ckan_result)
+        print(d)
+        assert d['categories'] == ['Politik und Wahlen']
 

--- a/tests/metautils_test.py
+++ b/tests/metautils_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# -*- coding: latin-1 -*-
+# -*- coding: utf-8 -*-
 import unittest
 import httpretty
 import pytest
@@ -12,3 +12,14 @@ class TestMetaUtils(object):
         assert metautils.isopen('dl-de-by-2.0') == 'Offen'
     def test_is_open_uppercase(self):
         assert metautils.isopen('CC BY 3.0 DE') == 'Offen'
+
+    def test_match_category(self):
+        assert metautils.matchCategory('Wahlen') == 'Politik und Wahlen'
+
+    def test_match_category_short(self):
+        assert metautils.matchCategory('Haushalt und Steuern') == u'Öffentliche Verwaltung, Haushalt und Steuern'
+
+    def test_categories(self):
+        categories = (u'Bildung und Wissenschaft', 'Wahlen')
+        assert metautils.matchCategories(categories) == ['Bildung und Wissenschaft', 'Politik und Wahlen']
+


### PR DESCRIPTION
## What does this PR do?

It fixes a typo which caused the CKAN/DKAN cities to not have categories at all
Furthermore it allows a dataset to have multiple categories. Previously only one was assigned. 